### PR TITLE
fix from gcc 5 to 8 compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.8)
-project(iridium VERSION 4.1.0)
+cmake_minimum_required(VERSION 3.5)
+project(iridium VERSION 4.1.1)
 
 #----------------#
 # Global options #
@@ -18,8 +18,8 @@ set(CMAKE_SUPPRESS_REGENERATION ON)
 set(CMAKE_SKIP_PACKAGE_ALL_DEPENDENCY ON)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 set(COMMIT_ID_IN_VERSION ON CACHE BOOL "Include git commit # in Version")
-set(STATIC ON CACHE BOOL "Link libraries statically")
 set(BUILD_TESTS OFF CACHE BOOL "build tests")
+set(PORTABLE ON)
 
 #----------------#
 # Cooking stuffs #
@@ -199,6 +199,7 @@ message(STATUS "========== building ${PROJECT_NAME} Core version : ${PROJECT_VER
 message(STATUS "Compiler : ${CMAKE_CXX_COMPILER_ID} version ${CMAKE_CXX_COMPILER_VERSION}")
 message(STATUS "Version : ${VERSION}")
 message(STATUS "Revision : ${COMMIT_ID}")
+message(STATUS "Arch : ${ARCH}")
 message(STATUS "Boost version : ${Boost_LIB_VERSION}")
 message(STATUS "Link libraries statically : ${STATIC}" )
 message(STATUS "Portable : ${PORTABLE}" )

--- a/external/miniupnpc/receivedata.c
+++ b/external/miniupnpc/receivedata.c
@@ -39,7 +39,7 @@ receivedata(int socket,
             char * data, int length,
             int timeout, unsigned int * scope_id)
 {
-#if MINIUPNPC_GET_SRC_ADDR
+#ifdef MINIUPNPC_GET_SRC_ADDR
 #ifdef DEBUG
 	/* to shut up valgrind about uninit value */
 	struct sockaddr_storage src_addr = {0};
@@ -84,7 +84,7 @@ receivedata(int socket,
         return 0;
     }
 #endif
-#if MINIUPNPC_GET_SRC_ADDR
+#ifdef MINIUPNPC_GET_SRC_ADDR
 	n = recvfrom(socket, data, length, 0,
 	             (struct sockaddr *)&src_addr, &src_addr_len);
 #else
@@ -93,7 +93,7 @@ receivedata(int socket,
 	if(n<0) {
 		PRINT_SOCKET_ERROR("recv");
 	}
-#if MINIUPNPC_GET_SRC_ADDR
+#ifdef MINIUPNPC_GET_SRC_ADDR
 	if (src_addr.ss_family == AF_INET6) {
 		const struct sockaddr_in6 * src_addr6 = (struct sockaddr_in6 *)&src_addr;
 #ifdef DEBUG

--- a/external/rocksdb/CMakeLists.txt
+++ b/external/rocksdb/CMakeLists.txt
@@ -32,7 +32,7 @@
 # 3. cmake ..
 # 4. make -j
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.5)
 project(rocksdb)
 enable_language(CXX)
 enable_language(C)

--- a/src/CryptoNoteCore/DatabaseBlockchainCache.cpp
+++ b/src/CryptoNoteCore/DatabaseBlockchainCache.cpp
@@ -303,6 +303,9 @@ public:
     ++globalOutputIndex;
   }
 
+  void decrement() {
+  }
+
   void advance(difference_type n) {
     assert(n >= -static_cast<difference_type>(globalOutputIndex));
     globalOutputIndex += static_cast<uint32_t>(n);

--- a/src/NodeRpcProxy/NodeRpcProxy.cpp
+++ b/src/NodeRpcProxy/NodeRpcProxy.cpp
@@ -86,6 +86,7 @@ void NodeRpcProxy::resetInternalState() {
   lastLocalBlockHeaderInfo.difficulty = 0;
   lastLocalBlockHeaderInfo.reward = 0;
   m_knownTxs.clear();
+  m_lastHash = CryptoNote::NULL_HASH;
 }
 
 void NodeRpcProxy::init(const INode::Callback& callback) {
@@ -441,7 +442,7 @@ void NodeRpcProxy::getPoolSymmetricDifference(std::vector<Crypto::Hash>&& knownP
     return;
   }
 
-  if(knownBlockId == nullHash) {
+  if(knownBlockId == CryptoNote::NULL_HASH) {
         knownBlockId = m_lastHash;
   }
 
@@ -629,7 +630,7 @@ std::error_code NodeRpcProxy::doGetPoolSymmetricDifference(std::vector<Crypto::H
   req.tailBlockId = knownBlockId;
   req.knownTxsIds = knownPoolTxIds;
 
-  if(m_lastHash == nullHash) {
+  if(m_lastHash == CryptoNote::NULL_HASH) {
         m_lastHash = knownBlockId;
   }
 

--- a/src/NodeRpcProxy/NodeRpcProxy.h
+++ b/src/NodeRpcProxy/NodeRpcProxy.h
@@ -138,8 +138,7 @@ private:
   BlockHeaderInfo lastLocalBlockHeaderInfo;
   //protect it with mutex if decided to add worker threads
   std::unordered_set<Crypto::Hash> m_knownTxs;
-  Crypto::Hash m_lastHash = {0};
-  Crypto::Hash nullHash = {0};
+  Crypto::Hash m_lastHash;
 
   bool m_connected;
 };


### PR DESCRIPTION
* fix gcc 5.4 compilation by initializing arrays in a cleaner way (resolve #27)
* define cmake minimum version to 3.5 for backward compatibility
* add a decrement() method for gcc 8
* tested on ubuntu 16.04 18.04, 19.04 and fedora 29 with gcc 5,7,8 and
boost 1.58 to 1.67